### PR TITLE
Missing parenthesis

### DIFF
--- a/include/etap.hrl
+++ b/include/etap.hrl
@@ -43,4 +43,4 @@
         catch
             _:E ->
                 ?etap_match(E, ErrMatch, Desc)
-        end.
+        end).


### PR DESCRIPTION
It seems that there is more strict checker of macro-definitions in Erlang/OTP R14 - see build logs:

http://koji.fedoraproject.org/koji/taskinfo?taskID=2548221

This patch adds missing right closing parenthesis. I re-checked - it doesn't add build issues on R11B, R12B and R13B:

R11B: http://koji.fedoraproject.org/koji/taskinfo?taskID=2548389
R12B: http://koji.fedoraproject.org/koji/taskinfo?taskID=2548384
R13B: http://koji.fedoraproject.org/koji/taskinfo?taskID=2548368
R14B: http://koji.fedoraproject.org/koji/taskinfo?taskID=2548348
